### PR TITLE
Refactor TypeLocator to TypeParser, simpler interface.

### DIFF
--- a/src/__snapshots__/functionEmitter.test.ts.snap
+++ b/src/__snapshots__/functionEmitter.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`emit validator for Object with array of numbers 1`] = `
+"function isArrayOfNumbers(value: unknown): value is ArrayOfNumbers {
+    return ((Object(value) === value) && ((((Array.isArray(value.scores)) && (value.scores.every(element => typeof element === 'number'))))))
+}"
+`;
+
 exports[`emit validator for null 1`] = `
 "function isNull(value: unknown): value is Null {
     return value === null

--- a/src/__snapshots__/prettyPrinter.test.ts.snap
+++ b/src/__snapshots__/prettyPrinter.test.ts.snap
@@ -27,16 +27,3 @@ exports[`pretty prints simple objects 1`] = `
   b: [number, string]
 }"
 `;
-
-exports[`pretty recursive types 1`] = `
-"{ [CompositionWithRecursive]
-  t: { [Recursive33]
-    d: { [Recursive31]
-      a: { [Recursive32]
-        b: RecursiveReference<Recursive32>
-        c: RecursiveReference<Recursive33>
-      }
-    }
-  }
-}"
-`;

--- a/src/functionEmitter.test.ts
+++ b/src/functionEmitter.test.ts
@@ -1,9 +1,10 @@
 import {FunctionEmitter} from './functionEmitter'
 import {
+    ArrayType,
     LiteralStringType,
     NamedType,
     nullableType,
-    nullType,
+    nullType, numberType,
     ObjectType,
     stringType,
     UnionType,
@@ -30,6 +31,18 @@ test('emit validator for reasonably complicated object type', () => {
                 LiteralStringType.Of('person'),
             ]),
         }),
+    )
+    expect(fnEmitter.typeToFunctionSource(toValidate)).toMatchSnapshot()
+})
+
+test('emit validator for Object with array of numbers', () => {
+    const toValidate = NamedType.Of(
+        'ArrayOfNumbers',
+        'unknown',
+        false,
+        ObjectType.Of({
+            scores: ArrayType.Of(numberType),
+        })
     )
     expect(fnEmitter.typeToFunctionSource(toValidate)).toMatchSnapshot()
 })

--- a/src/lang/arrays.test.ts
+++ b/src/lang/arrays.test.ts
@@ -1,0 +1,35 @@
+import {Arrays} from './arrays'
+
+const noReachCmp = (a: any, b: any) => fail()
+const cmp = (a: any, b: any) => a === b
+
+test('empty arrays are equal', () => {
+    expect(Arrays.equal([], [], noReachCmp)).toBe(true)
+})
+
+test('single element arrays are equal depending on that single element', () => {
+    const e1 = 1
+    const e2 = 2
+    expect(Arrays.equal([e1], [e1], cmp)).toBe(true)
+    expect(Arrays.equal([e1], [e2], cmp)).toBe(false)
+    expect(Arrays.equal([e2], [e1], cmp)).toBe(false)
+})
+test('different length arrays are not equal', () => {
+    expect(Arrays.equal([1], [], noReachCmp)).toBe(false)
+    expect(Arrays.equal([], [1], noReachCmp)).toBe(false)
+})
+test('different permutation is not equal', () => {
+    expect(Arrays.equal([1, 2], [2, 1], cmp)).toBe(false)
+})
+
+test('custom comparison determines equality', () => {
+        interface AB {
+            a: number,
+            b: number
+        }
+
+        const projectionEq = (e1: AB, e2: AB) => e1.a === e2.a
+        expect(Arrays.equal([{a: 10, b: 20}], [{a: 10, b: 30}], projectionEq)).toBe(true)
+        expect(Arrays.equal([{a: 10, b: 20}], [{a: 20, b: 20}], projectionEq)).toBe(false)
+    }
+)

--- a/src/lang/arrays.test.ts
+++ b/src/lang/arrays.test.ts
@@ -35,3 +35,15 @@ test('custom comparison determines equality', () => {
         expect(Arrays.equal([{a: 10, b: 20}], [{a: 20, b: 20}], projectionEq)).toBe(false)
     }
 )
+
+test('isPermutation is true for the same array', () => {
+    expect(Arrays.isPermutation([1, 2, 3], [1, 2, 3], cmp)).toBe(true)
+})
+
+test('isPermutation is true for the reverse order', () => {
+    expect(Arrays.isPermutation([1, 2, 3], [3, 2, 1], cmp)).toBe(true)
+})
+
+test('isPermutation is false if they have different elements', () => {
+    expect(Arrays.isPermutation([1, 2, 3], [3, 2, 4], cmp)).toBe(false)
+})

--- a/src/lang/arrays.test.ts
+++ b/src/lang/arrays.test.ts
@@ -14,10 +14,12 @@ test('single element arrays are equal depending on that single element', () => {
     expect(Arrays.equal([e1], [e2], cmp)).toBe(false)
     expect(Arrays.equal([e2], [e1], cmp)).toBe(false)
 })
+
 test('different length arrays are not equal', () => {
     expect(Arrays.equal([1], [], noReachCmp)).toBe(false)
     expect(Arrays.equal([], [1], noReachCmp)).toBe(false)
 })
+
 test('different permutation is not equal', () => {
     expect(Arrays.equal([1, 2], [2, 1], cmp)).toBe(false)
 })

--- a/src/lang/arrays.ts
+++ b/src/lang/arrays.ts
@@ -1,0 +1,33 @@
+import {isNil} from '../errors'
+
+export class Arrays {
+    static equal<T>(a1: T[], a2: T[], comparison: (e1: T, e2: T) => boolean): boolean {
+        return a1.length === a2.length && a1.every((e1, i) => comparison(e1, a2[i]))
+    }
+
+    static isPermutation<T>(a1: T[], a2: T[], comparison: (e1: T, e2: T) => boolean): boolean {
+        if (Arrays.equal(a1, a2, comparison)) {
+            return true
+        }
+        const a2copy = a2.slice()
+        for (const searchingFor of a1) {
+            const foundAt = Arrays.findIndex(searchingFor, a2copy, comparison)
+            if (isNil(foundAt)) {
+                return false
+            }
+            a2copy.splice(foundAt, 1)
+        }
+        return true
+    }
+
+    static findIndex<T>(element: T, a: T[], comparison: (e1: T, e2: T) => boolean): number | null {
+        let index = 0
+        for (const candidate of a) {
+            if (comparison(element, candidate)) {
+                return index
+            }
+            index += 1
+        }
+        return null
+    }
+}

--- a/src/lang/arrays.ts
+++ b/src/lang/arrays.ts
@@ -4,30 +4,4 @@ export class Arrays {
     static equal<T>(a1: T[], a2: T[], comparison: (e1: T, e2: T) => boolean): boolean {
         return a1.length === a2.length && a1.every((e1, i) => comparison(e1, a2[i]))
     }
-
-    static isPermutation<T>(a1: T[], a2: T[], comparison: (e1: T, e2: T) => boolean): boolean {
-        if (Arrays.equal(a1, a2, comparison)) {
-            return true
-        }
-        const a2copy = a2.slice()
-        for (const searchingFor of a1) {
-            const foundAt = Arrays.findIndex(searchingFor, a2copy, comparison)
-            if (isNil(foundAt)) {
-                return false
-            }
-            a2copy.splice(foundAt, 1)
-        }
-        return true
-    }
-
-    static findIndex<T>(element: T, a: T[], comparison: (e1: T, e2: T) => boolean): number | null {
-        let index = 0
-        for (const candidate of a) {
-            if (comparison(element, candidate)) {
-                return index
-            }
-            index += 1
-        }
-        return null
-    }
 }

--- a/src/lang/arrays.ts
+++ b/src/lang/arrays.ts
@@ -1,7 +1,34 @@
 import {isNil} from '../errors'
 
+function findIndex<T>(element: T, a: T[], comparison: (e1: T, e2: T) => boolean): number | null {
+    let index = 0
+    for (const candidate of a) {
+        if (comparison(element, candidate)) {
+            return index
+        }
+        index += 1
+    }
+    return null
+}
+
 export class Arrays {
     static equal<T>(a1: T[], a2: T[], comparison: (e1: T, e2: T) => boolean): boolean {
         return a1.length === a2.length && a1.every((e1, i) => comparison(e1, a2[i]))
     }
+
+    static isPermutation<T>(a1: T[], a2: T[], comparison: (e1: T, e2: T) => boolean): boolean {
+        if (Arrays.equal(a1, a2, comparison)) {
+            return true
+        }
+        const a2copy = a2.slice()
+        for (const searchingFor of a1) {
+            const foundAt = findIndex(searchingFor, a2copy, comparison)
+            if (isNil(foundAt)) {
+                return false
+            }
+            a2copy.splice(foundAt, 1)
+        }
+        return true
+    }
+
 }

--- a/src/lang/maps.test.ts
+++ b/src/lang/maps.test.ts
@@ -1,0 +1,43 @@
+import {Arrays} from './arrays'
+import {Maps} from './maps'
+
+const noReachCmp = (e1: any, e2: any) => fail()
+
+const cmp = (e1: any, e2: any) => e1 === e2
+
+test('empty maps are equal', () => {
+    expect(Maps.equal(new Map(), new Map(), noReachCmp)).toBe(true)
+})
+
+test('single element maps are equal depending on that single element', () => {
+    const e1 = 1
+    const e2 = 2
+    expect(Maps.equal(new Map([['test', e1]]), new Map([['test', e1]]), cmp)).toBe(true)
+    expect(Maps.equal(new Map([['test', e1]]), new Map([['test', e2]]), cmp)).toBe(false)
+    expect(Maps.equal(new Map([['test', e2]]), new Map([['test', e1]]), cmp)).toBe(false)
+})
+
+test('maps with different keys are not equal', () => {
+    expect(Maps.equal(new Map([['test', 1]]), new Map([['otherKey', 1]]), noReachCmp)).toBe(false)
+    expect(Maps.equal(new Map([['otherKey', 1]]), new Map([['test', 1]]), noReachCmp)).toBe(false)
+})
+
+test('custom comparison determines equality', () => {
+        interface AB {
+            a: number,
+            b: number
+        }
+
+        const e12 = {a: 1, b: 2}
+        const e13 = {a: 1, b: 3}
+        const e22 = {a: 2, b: 2}
+
+        const projectionEq = (e1: AB, e2: AB) => e1.a === e2.a
+        expect(
+            Maps.equal(new Map([['test', e12]]), new Map([['test', e13]]), projectionEq)
+        ).toBe(true)
+        expect(
+            Maps.equal(new Map([['test', e12]]), new Map([['test', e22]]), projectionEq)
+        ).toBe(false)
+    }
+)

--- a/src/lang/maps.ts
+++ b/src/lang/maps.ts
@@ -1,0 +1,13 @@
+import {checkNotNil, isNil} from '../errors'
+
+export class Maps {
+    static equal<K, T>(m1: Map<K, T>, m2: Map<K, T>, comparison: (e1: T, e2: T) => boolean): boolean {
+        return Array.from(m1.keys()).every(key => {
+            const e2 = m2.get(key)
+            if (isNil(e2)) {
+                return false
+            }
+            return comparison(checkNotNil(m1.get(key)), e2)
+        })
+    }
+}

--- a/src/prettyPrinter.test.ts
+++ b/src/prettyPrinter.test.ts
@@ -11,7 +11,6 @@ import {
     nullType,
     numberType,
     ObjectType,
-    RecursiveReferenceType,
     stringType,
     TupleType,
     undefinedType,
@@ -70,20 +69,4 @@ test('pretty nested objects', () => {
         at: ArrayType.Of(nested),
     })
     expect(ot.accept(pp).toString()).toMatchSnapshot()
-})
-
-test('pretty recursive types', () => {
-    const rec32 = new RecursiveReferenceType(null)
-    const rec31 = RecursiveReferenceType.Of(
-        NamedType.Of('Recursive31', 'test', true, ObjectType.Of({a: rec32}))
-    )
-    const rec33 = RecursiveReferenceType.Of(
-        NamedType.Of('Recursive33', 'test', true, ObjectType.Of({d: rec31}))
-    )
-    rec32.resolve(NamedType.Of('Recursive32', 'test', true, ObjectType.Of({b: rec32, c: rec33})))
-
-    const rec1 = RecursiveReferenceType.Of(
-        NamedType.Of('CompositionWithRecursive', 'test', true, ObjectType.Of({t: rec33}))
-    )
-    expect(rec1.accept(pp).toString()).toMatchSnapshot()
 })

--- a/src/typeParser.test.ts
+++ b/src/typeParser.test.ts
@@ -47,6 +47,6 @@ test('Array of numbers within an object gets properly parsed', () => {
             ObjectType.Of({scores: ArrayType.Of(numberType)})
         )
 
-        expect(parsed.equal(expected)).toBe(true)
+        expect(parsed.equalDeclaration(expected)).toBe(true)
     }
 )

--- a/src/typeParser.test.ts
+++ b/src/typeParser.test.ts
@@ -1,0 +1,52 @@
+import * as ts from 'typescript'
+
+import {TypeParser} from './typeParser'
+import {TypePrettyPrinter} from './typePrettyPrinter'
+import {ArrayType, NamedType, numberType, ObjectType, Type} from './types'
+
+const INLINE_MODULE = 'inline.ts'
+
+function parseTypeFromSource(typeName: string, source: string): NamedType {
+    // this shares a bunch of setup from repl, meaning it should all be better encapsulated
+    // by typeParser
+
+    const fakeSourceFile = ts.createSourceFile('inline.ts', source, ts.ScriptTarget.ES5)
+    const compilerHost = ts.createCompilerHost({})
+    const fallbackGetSourceFile = compilerHost.getSourceFile
+    compilerHost.getSourceFile = (
+        fileName: string, languageVersion: ts.ScriptTarget,
+        onError?: (message: string) => void,
+        shouldCreateNewSourceFile?: boolean
+    ): ts.SourceFile | undefined => {
+        if (fileName === INLINE_MODULE) {
+            return fakeSourceFile
+        }
+        return fallbackGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
+
+    }
+    const program = ts.createProgram([INLINE_MODULE], {}, compilerHost)
+    const locator = new TypeParser(program)
+    return locator.parseType(INLINE_MODULE, typeName)
+}
+
+function prettyPrintType(type: Type): string {
+    const prettyPrinter = new TypePrettyPrinter()
+    return type.accept(prettyPrinter).toString()
+}
+
+test('Array of numbers within an object gets properly parsed', () => {
+
+        const parsed = parseTypeFromSource('Sample', `
+        export interface Sample {
+            scores: number[]
+        }`)
+        const expected = NamedType.Of(
+            'Sample',
+            INLINE_MODULE,
+            true,
+            ObjectType.Of({scores: ArrayType.Of(numberType)})
+        )
+
+        expect(parsed.equal(expected)).toBe(true)
+    }
+)

--- a/src/typeParser.ts
+++ b/src/typeParser.ts
@@ -4,40 +4,49 @@
  */
 import * as ts from 'typescript'
 
-import {checkNotNil, checkState, fail, isNil} from './errors'
+import {checkNotNil, fail} from './errors'
 import {
+    ArrayType,
     booleanType,
     IntersectionType,
     LiteralBooleanType,
     LiteralNumberType,
-    LiteralStringType, NamedType,
+    LiteralStringType,
+    NamedType,
     nullType,
     numberType,
     ObjectType,
-    RecursiveReferenceType,
     stringType,
     TupleType,
     Type,
-    TypeName,
     undefinedType,
     UnionType,
 } from './types'
 
 // tslint:disable:completed-docs
 
-interface TypeLocator {
-    find(filename: string, typeName: string): ts.Node | undefined
-}
-
 interface TypescriptTypeToValidatorType {
     resolve(tsType: ts.Type, node: ts.Node): Type
 }
 
-export class SimpleFileLocator implements TypeLocator {
+export class TypeParser {
+    private mapper: TypeMapper
+
     constructor(private program: ts.Program) {
+        this.mapper = new TypeMapper(program)
     }
 
-    find(filename: string, lookupName: string): ts.Node | undefined {
+    parseType(filename: string, typeName: string): NamedType {
+        const checker = this.program.getTypeChecker()
+        const node = checkNotNil(this.find(filename, typeName))
+        const tsType = checker.getTypeAtLocation(node)
+        const mappedType = this.mapper.resolve(tsType)
+        return NamedType.Of(
+            checker.typeToString(tsType), filename, true, mappedType
+        )
+    }
+
+    private find(filename: string, lookupName: string): ts.Node | undefined {
         const sourceFile = checkNotNil(this.program.getSourceFile(filename))
 
         return ts.forEachChild(sourceFile, node => this.visitTopLevel(node, lookupName))
@@ -72,131 +81,15 @@ function sortByName(propertiesOfType: ts.Symbol[]): ts.Symbol[] {
     })
 }
 
-export class TypeStack {
-    private stack: ts.Type[]
-    private visiting: Set<ts.Type>
-
-    constructor() {
-        this.stack = []
-        this.visiting = new Set()
-    }
-
-    push(tsType: ts.Type): void {
-        checkState(!this.has(tsType))
-        this.stack.push(tsType)
-        this.visiting.add(tsType)
-    }
-
-    pop(): void {
-        const tsType = checkNotNil(this.stack.pop())
-        this.visiting.delete(tsType)
-    }
-
-    has(tsType: ts.Type): boolean {
-        return this.visiting.has(tsType)
-    }
-}
-
-class RecursiveTypeRegistry {
-    recursiveTypesBySource: Map<ts.Type, NamedType>
-    pendingReferences: Map<ts.Type, RecursiveReferenceType[]>
-
-    constructor() {
-        this.recursiveTypesBySource = new Map()
-        this.pendingReferences = new Map()
-    }
-
-    addMaybeRecursiveType(source: ts.Type, resolved: Type): Type {
-        if (this.isRecursive(source)) {
-            this.addKnownRecursiveType(source, resolved as any)
-
-            return new RecursiveReferenceType(resolved as any)
-        }
-
-        return resolved
-    }
-
-    makeRecursiveReference(source: ts.Type): RecursiveReferenceType {
-        if (this.recursiveTypesBySource.has(source)) {
-            return new RecursiveReferenceType(checkNotNil(this.recursiveTypesBySource.get(source)))
-        }
-
-        return this.makePendingRecursiveReference(source)
-    }
-
-    addKnownRecursiveType(source: ts.Type, target: NamedType): void {
-        checkState(!this.recursiveTypesBySource.has(source))
-        this.recursiveTypesBySource.set(source, target)
-        this.resolvePendingReferences(source)
-    }
-
-    isRecursive(source: ts.Type): boolean {
-        return this.recursiveTypesBySource.has(source) || this.pendingReferences.has(source)
-    }
-
-    private makePendingRecursiveReference(source: ts.Type): RecursiveReferenceType {
-        if (!this.pendingReferences.has(source)) {
-            this.pendingReferences.set(source, [])
-        }
-        const ref = new RecursiveReferenceType(null)
-        checkNotNil(this.pendingReferences.get(source)).push(ref)
-
-        return ref
-    }
-
-    private resolvePendingReferences(source: ts.Type): void {
-        const resolveTo = checkNotNil(this.recursiveTypesBySource.get(source))
-        const pendingReferences = this.pendingReferences.get(source)
-        if (isNil(pendingReferences)) {
-            return
-        }
-        for (const ref of pendingReferences) {
-            ref.resolve(resolveTo)
-        }
-        this.pendingReferences.delete(source)
-
-    }
-}
-
 export class TypeMapper implements TypescriptTypeToValidatorType {
     private checker: ts.TypeChecker
-    private recursiveTypes: RecursiveTypeRegistry
 
     constructor(private program: ts.Program) {
         this.checker = program.getTypeChecker()
-        this.recursiveTypes = new RecursiveTypeRegistry()
-    }
-
-    resolve(tsType: ts.Type): Type {
-        return this.internalMap(tsType, new TypeStack())
-    }
-
-    internalMap(source: ts.Type, stack: TypeStack): Type {
-        if (stack.has(source)) {
-            return this.recursiveTypes.makeRecursiveReference(source)
-        }
-        stack.push(source)
-        const resolved = this.safeStepMap(source, stack)
-        const resolvedWithMaybeName = this.makeMaybeNamedType(source, resolved)
-        if (this.recursiveTypes.isRecursive(source)) {
-            this.recursiveTypes.addKnownRecursiveType(source, resolvedWithMaybeName as any)
-        }
-        stack.pop()
-
-        return resolvedWithMaybeName
-    }
-
-    private makeMaybeNamedType(source: ts.Type, target: Type): NamedType | Type {
-        const tsSymbol = source.getSymbol()
-        if (isNil(tsSymbol)) {
-            return target
-        } else {
-            return new NamedType(tsSymbol.getName(), 'unknown', true, target)
-        }
     }
 
     // tslint:disable:no-bitwise
-    private safeStepMap(tsType: ts.Type, stack: TypeStack): Type {
+    resolve(tsType: ts.Type): Type {
         if (tsType.flags & ts.TypeFlags.Null) {
             return nullType
         } else if (tsType.flags & ts.TypeFlags.Undefined) {
@@ -208,13 +101,13 @@ export class TypeMapper implements TypescriptTypeToValidatorType {
         } else if (tsType.flags & ts.TypeFlags.Boolean) {
             return booleanType
         } else if (this.isObjectType(tsType)) {
-            return this.dispatchObjectTypes(tsType, stack)
+            return this.dispatchObjectTypes(tsType)
         } else if (this.isIntersectionType(tsType)) {
-            return this.mapIntersectionOfTypes(tsType.types, stack)
+            return this.mapIntersectionOfTypes(tsType.types)
         } else if (this.isLiteralType(tsType)) {
             return this.mapLiteralType(tsType)
         } else if (this.isUnionType(tsType)) {
-            return this.mapUnionOfTypes(tsType.types, stack)
+            return this.mapUnionOfTypes(tsType.types)
         } else {
             return fail(`Unknown type flags ${tsType.flags}`)
         }
@@ -232,33 +125,30 @@ export class TypeMapper implements TypescriptTypeToValidatorType {
         return !!(tsType.flags & ts.TypeFlags.Union)
     }
 
-    private mapArrayType(tsType: ts.Type, stack: TypeStack): Type {
-        return this.internalMap(tsType, stack)
+    private mapArrayType(tsType: ts.Type): Type {
+        return ArrayType.Of(this.resolve(tsType))
     }
 
-    private mapObjectType(tsType: ts.Type, stack: TypeStack): Type {
+    private mapObjectType(tsType: ts.Type): Type {
         const mapped = new ObjectType()
         const properties = sortByName(this.checker.getPropertiesOfType(tsType))
         for (const property of properties) {
             const propertyNode = checkNotNil(property.valueDeclaration)
             const propertyType = this.checker.getTypeOfSymbolAtLocation(property, propertyNode)
-            const mappedType = this.internalMap(propertyType, stack)
+            const mappedType = this.resolve(propertyType)
             if (mappedType) {
                 mapped.addProperty(property.name, mappedType)
             }
         }
-
-        return NamedType.Of(
-            this.checker.typeToString(tsType), 'unknown', true, mapped
-        )
+        return mapped
     }
 
-    private mapUnionOfTypes(tsTypes: ts.Type[], stack: TypeStack): Type {
-        return UnionType.Of(tsTypes.map(tsType => this.internalMap(tsType, stack)))
+    private mapUnionOfTypes(tsTypes: ts.Type[]): Type {
+        return UnionType.Of(tsTypes.map(tsType => this.resolve(tsType)))
     }
 
-    private mapIntersectionOfTypes(tsTypes: ts.Type[], stack: TypeStack): Type {
-        return IntersectionType.Of(tsTypes.map(tsType => this.internalMap(tsType, stack)))
+    private mapIntersectionOfTypes(tsTypes: ts.Type[]): Type {
+        return IntersectionType.Of(tsTypes.map(tsType => this.resolve(tsType)))
 
     }
 
@@ -297,31 +187,31 @@ export class TypeMapper implements TypescriptTypeToValidatorType {
         return (tsType.flags & ts.TypeFlags.Object) !== 0
     }
 
-    private mapTypeReference(tsType: ts.TypeReference, stack: TypeStack): Type {
-        return this.mapObjectType(tsType, stack)
+    private mapTypeReference(tsType: ts.TypeReference): Type {
+        return this.mapObjectType(tsType)
     }
 
-    private mapTupleType(tsType: ts.TypeReference, stack: TypeStack): Type {
+    private mapTupleType(tsType: ts.TypeReference): Type {
         const positionalTypes = checkNotNil(tsType.typeArguments).map(
-            argument => this.internalMap(argument, stack)
+            argument => this.resolve(argument)
         )
 
         return TupleType.Of(positionalTypes)
     }
 
-    private dispatchObjectTypes(tsType: ts.ObjectType, stack: TypeStack): Type {
+    private dispatchObjectTypes(tsType: ts.ObjectType): Type {
         if (this.isTypeReference(tsType)) {
             if (this.isArrayType(tsType)) {
-                return this.mapArrayType(checkNotNil(tsType.typeArguments)[0], stack)
+                return this.mapArrayType(checkNotNil(tsType.typeArguments)[0])
             } else if (this.isTupleType(tsType)) {
-                return this.mapTupleType(tsType, stack)
+                return this.mapTupleType(tsType)
             }
 
-            return this.mapTypeReference(tsType, stack)
+            return this.mapTypeReference(tsType)
         } else if (this.isFunctionType(tsType)) {
             return fail('Cannot validate function type')
         } else {
-            return this.mapObjectType(tsType, stack)
+            return this.mapObjectType(tsType)
         }
 
     }

--- a/src/typeParser.ts
+++ b/src/typeParser.ts
@@ -41,9 +41,7 @@ export class TypeParser {
         const node = checkNotNil(this.find(filename, typeName))
         const tsType = checker.getTypeAtLocation(node)
         const mappedType = this.mapper.resolve(tsType)
-        return NamedType.Of(
-            checker.typeToString(tsType), filename, true, mappedType
-        )
+        return NamedType.Of(typeName, filename, true, mappedType)
     }
 
     private find(filename: string, lookupName: string): ts.Node | undefined {

--- a/src/typePrettyPrinter.ts
+++ b/src/typePrettyPrinter.ts
@@ -10,14 +10,13 @@ import {
     LiteralStringType, NamedType,
     ObjectType,
     PrimitiveType,
-    RecursiveReferenceType,
     TupleType,
     Type,
     TypeVisitor,
     UnionType,
 } from './types'
 
-import {checkNotNil, fail, isNil} from './errors'
+import {fail} from './errors'
 
 /**
  * A prettified type fragment that fits in a single line.
@@ -83,11 +82,6 @@ type PrettyType = PrettyInline | PrettyBlock
  * Transform a parsed type to a pretty printed version of it.
  */
 export class TypePrettyPrinter implements TypeVisitor<PrettyType> {
-    private visitedRecursiveStack: Type[]
-
-    constructor() {
-        this.visitedRecursiveStack = []
-    }
 
     visitPrimitive(p: PrimitiveType): PrettyType {
         return new PrettyInline(p.target)
@@ -174,19 +168,6 @@ export class TypePrettyPrinter implements TypeVisitor<PrettyType> {
 
     visitLiteralBoolean(literal: LiteralBooleanType): PrettyType {
         return new PrettyInline(`'${literal.value}'`)
-    }
-
-    visitRecursiveReference(ref: RecursiveReferenceType): PrettyType {
-        const name = checkNotNil(ref.getTarget().name, 'expected recursive type to have a name')
-        const target = ref.getTarget()
-        if (!isNil(this.visitedRecursiveStack.find(t => t === target))) {
-            return new PrettyInline(`RecursiveReference<${name}>`)
-        }
-        this.visitedRecursiveStack.push(target)
-        const prettified = ref.getTarget().accept(this)
-        this.visitedRecursiveStack.pop()
-
-        return prettified
     }
 
     visitNamedType(t: NamedType): PrettyType {

--- a/src/typeToValidation.ts
+++ b/src/typeToValidation.ts
@@ -10,7 +10,6 @@ import {
     ObjectType,
     PrimitiveType,
     PrimitiveTypes,
-    RecursiveReferenceType,
     TupleType,
     Type,
     TypeVisitor,
@@ -28,7 +27,6 @@ import {
     PrimitiveNumberValidation,
     PrimitiveStringValidation,
     PropertyValidation,
-    RecursiveValidation,
     ReferencableValidation,
     SomeRequiredValidation,
     Validation,
@@ -97,10 +95,6 @@ export class TypeToValidationVisitor implements TypeVisitor<Validation> {
 
     visitLiteralBoolean(literal: LiteralBooleanType): Validation {
         return new PrimitiveBooleanValidation(literal.value)
-    }
-
-    visitRecursiveReference(ref: RecursiveReferenceType): Validation {
-        return new RecursiveValidation(ref.getTarget())
     }
 
     visitNamedType(udt: NamedType): Validation {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -66,3 +66,16 @@ test('types are equal to themselves, but not equal to other types or different d
         }
     }
 )
+
+test('Intersection and union types are equal disregarding their parts order', () => {
+    expect(
+        UnionType.Of([stringType, numberType]).equalDeclaration(
+            UnionType.Of([numberType, stringType])
+        )
+    ).toBe(true)
+    expect(
+        IntersectionType.Of([stringType, numberType]).equalDeclaration(
+            IntersectionType.Of([numberType, stringType])
+        )
+    ).toBe(true)
+})

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,68 @@
+import {TypePrettyPrinter} from './typePrettyPrinter'
+import {
+    ArrayType,
+    booleanType,
+    EnumType,
+    IntersectionType,
+    LiteralBooleanType,
+    LiteralNumberType,
+    LiteralStringType,
+    NamedType,
+    nullType,
+    numberType,
+    ObjectType,
+    stringType,
+    TupleType,
+    Type,
+    undefinedType,
+    UnionType,
+} from './types'
+
+const ppVisitor = new TypePrettyPrinter()
+
+function prettyPrintType(t: Type): string {
+    return t.accept(ppVisitor).toString()
+}
+
+test('types are equal to themselves, but not equal to other types or different declarations',
+    () => {
+        const types: Type[] = [
+            numberType,
+            stringType,
+            booleanType,
+            nullType,
+            undefinedType,
+            ObjectType.Of({}),
+            ObjectType.Of({a: booleanType}),
+            ArrayType.Of(nullType),
+            ArrayType.Of(stringType),
+            UnionType.Of([numberType, stringType]),
+            UnionType.Of([nullType, stringType]),
+            IntersectionType.Of([numberType, stringType]),
+            IntersectionType.Of([nullType, stringType]),
+            TupleType.Of([numberType, stringType]),
+            EnumType.Of({a: 10, b: 'test'}),
+            EnumType.Of({a: 20, b: 'test'}),
+            LiteralStringType.Of('test'),
+            LiteralStringType.Of('another'),
+            LiteralNumberType.Of(10),
+            LiteralNumberType.Of(20),
+            LiteralBooleanType.Of(true),
+            LiteralBooleanType.Of(false),
+            NamedType.Of('test', 'module', true, numberType),
+            NamedType.Of('another', 'module', true, numberType),
+        ]
+        for (let i = 0; i < types.length; i++) {
+            const base = types[i]
+            expect(base.equalDeclaration(base)).toBe(true)
+            for (const candidate of types.slice(0, i).concat(types.slice(i + 1, types.length))) {
+                if (base.equalDeclaration(candidate)) {
+                    const ppBase = prettyPrintType(base)
+                    const ppCandidate = prettyPrintType(candidate)
+                    throw new Error(`types are equal but should not: ${ppBase}\n ${ppCandidate}`)
+                }
+                expect(base.equalDeclaration(candidate)).toBe(false)
+            }
+        }
+    }
+)

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,15 @@ export class TupleType extends ListOfTypes implements Type {
 }
 
 export class EnumType implements Type {
+    static Of(spec: { [name: string]: string | number }): EnumType {
+        const target = new EnumType()
+        for (const property of Object.getOwnPropertyNames(spec)) {
+            target.add(property, spec[property])
+        }
+
+        return target
+    }
+
     members: Map<string, string | number>
 
     constructor() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,15 +211,6 @@ export class TupleType extends ListOfTypes implements Type {
 }
 
 export class EnumType implements Type {
-    static Of(spec: { [name: string]: string | number }): EnumType {
-        const target = new EnumType()
-        for (const property of Object.getOwnPropertyNames(spec)) {
-            target.add(property, spec[property])
-        }
-
-        return target
-    }
-
     members: Map<string, string | number>
 
     constructor() {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -118,16 +118,6 @@ export class EnumValueValidation implements Validation {
     }
 }
 
-export class RecursiveValidation implements Validation {
-    constructor(readonly ref: NamedType) {
-
-    }
-
-    accept<T>(visitor: ValidationVisitor<T>): T {
-        return visitor.visitRecursiveValidation(this)
-    }
-}
-
 export class ReferencableValidation implements Validation {
     constructor(readonly target: NamedType, readonly validation: Validation) {
 
@@ -160,8 +150,6 @@ export interface ValidationVisitor<T> {
     visitPrimitiveBoolean(p: PrimitiveBooleanValidation): T
 
     visitEnum(e: EnumValueValidation): T
-
-    visitRecursiveValidation(r: RecursiveValidation): T
 
     visitReferencableValidation(r: ReferencableValidation): T
 }

--- a/src/validationToJavascriptSource.ts
+++ b/src/validationToJavascriptSource.ts
@@ -9,9 +9,11 @@ import {
     PrimitiveBooleanValidation,
     PrimitiveNumberValidation,
     PrimitiveStringValidation,
-    PropertyValidation, RecursiveValidation,
+    PropertyValidation,
     ReferencableValidation,
-    SomeRequiredValidation, Validation, ValidationVisitor,
+    SomeRequiredValidation,
+    Validation,
+    ValidationVisitor,
 } from './validation'
 
 import {checkNotNil, fail} from './errors'
@@ -71,7 +73,7 @@ export class JavascriptSourceValidationVisitor implements ValidationVisitor<stri
         const validator = a.validator.accept(this)
         this.popName()
 
-        return `Array.every(element => ${validator}, ${this.currentName})`
+        return `${this.currentName}.every(element => ${validator})`
     }
 
     visitAllRequired(a: AllRequiredValidation): string {
@@ -112,11 +114,6 @@ export class JavascriptSourceValidationVisitor implements ValidationVisitor<stri
 
     visitEnum(e: EnumValueValidation): string {
         return fail('not implemented')
-    }
-
-    visitRecursiveValidation(r: RecursiveValidation): string {
-        return 'true'
-        // return fail("Expression emitter can't deal with recursive types")
     }
 
     visitReferencableValidation(r: ReferencableValidation): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": [
     "src/**/*.ts"
   ],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "build"],
   "compilerOptions": {
     "target": "es6",
     "module": "es6",


### PR DESCRIPTION
add tests for typeParser
remove (broken) support for recursive types.
Temporarily only parse named types for top level parsing.
Add helper methods for Arrays and Maps
Add an equals method for types.
Add utility collection functions for arrays and maps.